### PR TITLE
Вынесение меню прикладных сервисов из seaf-dzo-core

### DIFF
--- a/architecture/interface/menu_app.yaml
+++ b/architecture/interface/menu_app.yaml
@@ -1,0 +1,11 @@
+entities:
+  seaf.app.services.menu:
+    menu: >
+      (
+          [
+              {
+                  "location": "Архитектура/Прикладная/Сервисы",
+                  "link": 'entities/components/seaf.app.services.registry'
+              }
+          ]
+      )

--- a/architecture/interface/root.yaml
+++ b/architecture/interface/root.yaml
@@ -1,4 +1,5 @@
 imports:
   - menu.yaml
   - menuTA.yaml
+  - menu_app.yaml
   - presentation/root.yaml


### PR DESCRIPTION
Из репозитория seaf-dzo-core вынесено в пример меню с размещением таблицы прикладных сервисов

